### PR TITLE
feat: Add RBAC support for provinces, packs, testimonials, and testimonials sections management

### DIFF
--- a/spec/Provider/SyliusSectionsProviderSpec.php
+++ b/spec/Provider/SyliusSectionsProviderSpec.php
@@ -34,7 +34,7 @@ final class SyliusSectionsProviderSpec extends ObjectBehavior
                     'sylius_admin_tax_category',
                     'sylius_admin_tax_rate',
                     'sylius_admin_zone',
-                    'app_city',
+                    'app_pack',
                 ],
                 'customers_management' => [
                     'sylius_admin_customer',
@@ -55,6 +55,10 @@ final class SyliusSectionsProviderSpec extends ObjectBehavior
                     'sylius_admin_pages',
                     'sylius_admin_faq',
                     'sylius_admin_sections',
+                ],
+                'addressing' => [
+                    'app_city',
+                    'app_province',
                 ],
                 'custom' => [
                     'rbac' => [
@@ -80,6 +84,7 @@ final class SyliusSectionsProviderSpec extends ObjectBehavior
             'sales_management',
             'content_management',
             'rbac',
+            'addressing',
         ]);
     }
 }

--- a/src/Access/Creator/AccessRequestCreator.php
+++ b/src/Access/Creator/AccessRequestCreator.php
@@ -196,6 +196,11 @@ final class AccessRequestCreator implements AccessRequestCreatorInterface
                 return new AccessRequest(Section::cities(), $operationType);
             }
         }
+        foreach ($this->configuration['provinces_management'] as $provincesRoutePrefix){
+            if (str_starts_with($routeName, $provincesRoutePrefix)) {
+                return new AccessRequest(Section::provinces(), $operationType);
+            }
+        }
         foreach ($this->configuration['media_management'] as $mediaRoutePrefix){
             if (str_starts_with($routeName, $mediaRoutePrefix)) {
                 return new AccessRequest(Section::media(), $operationType);

--- a/src/Access/Creator/AccessRequestCreator.php
+++ b/src/Access/Creator/AccessRequestCreator.php
@@ -206,6 +206,16 @@ final class AccessRequestCreator implements AccessRequestCreatorInterface
                 return new AccessRequest(Section::packs(), $operationType);
             }
         }
+        foreach ($this->configuration['testimonials_management'] as $testimonialsRoutePrefix){
+            if (str_starts_with($routeName, $testimonialsRoutePrefix)) {
+                return new AccessRequest(Section::testimonials(), $operationType);
+            }
+        }
+        foreach ($this->configuration['testimonials_sections_management'] as $testimonialsSectionsRoutePrefix){
+            if (str_starts_with($routeName, $testimonialsSectionsRoutePrefix)) {
+                return new AccessRequest(Section::testimonialsSections(), $operationType);
+            }
+        }
         foreach ($this->configuration['media_management'] as $mediaRoutePrefix){
             if (str_starts_with($routeName, $mediaRoutePrefix)) {
                 return new AccessRequest(Section::media(), $operationType);

--- a/src/Access/Creator/AccessRequestCreator.php
+++ b/src/Access/Creator/AccessRequestCreator.php
@@ -201,6 +201,11 @@ final class AccessRequestCreator implements AccessRequestCreatorInterface
                 return new AccessRequest(Section::provinces(), $operationType);
             }
         }
+        foreach ($this->configuration['packs_management'] as $packsRoutePrefix){
+            if (str_starts_with($routeName, $packsRoutePrefix)) {
+                return new AccessRequest(Section::packs(), $operationType);
+            }
+        }
         foreach ($this->configuration['media_management'] as $mediaRoutePrefix){
             if (str_starts_with($routeName, $mediaRoutePrefix)) {
                 return new AccessRequest(Section::media(), $operationType);

--- a/src/Access/Menu/AdminMenuAccessListener.php
+++ b/src/Access/Menu/AdminMenuAccessListener.php
@@ -269,6 +269,18 @@ final class AdminMenuAccessListener
                 $bitbag_cms->removeChild('sections');
             }
         }
+        if ($this->hasAdminNoAccessToSection($adminUser, Section::testimonials())) {
+            $bitbag_cms = $menu->getChildren()['bitbag_cms'] ?? null;
+            if ($bitbag_cms) {
+                $bitbag_cms->removeChild('testimonials');
+            }
+        }
+        if ($this->hasAdminNoAccessToSection($adminUser, Section::testimonialsSections())) {
+            $bitbag_cms = $menu->getChildren()['bitbag_cms'] ?? null;
+            if ($bitbag_cms) {
+                $bitbag_cms->removeChild('testimonials_section');
+            }
+        }
         /** @var string $customSection */
         foreach (array_keys($this->configuration['custom']) as $customSection) {
             if ($this->hasAdminNoAccessToSection($adminUser, Section::ofType($customSection))) {

--- a/src/Access/Menu/AdminMenuAccessListener.php
+++ b/src/Access/Menu/AdminMenuAccessListener.php
@@ -32,9 +32,8 @@ final class AdminMenuAccessListener
 
         $menu = $event->getMenu();
 
-         if ($this->hasAdminNoAccessToSection($adminUser, Section::products())) {
+        if ($this->hasAdminNoAccessToSection($adminUser, Section::products())) {
             $catalog = $menu->getChildren()['catalog'] ?? null;
- 
             if ($catalog) {
                 $catalog->removeChild('products');
             }
@@ -81,14 +80,12 @@ final class AdminMenuAccessListener
                 $configuration->removeChild('channels');
             }
         }
-
         if ($this->hasAdminNoAccessToSection($adminUser, Section::countries())) {
             $configuration = $menu->getChildren()['configuration'] ?? null;
             if ($configuration) {
                 $configuration->removeChild('countries');
             }
         }
-
         if ($this->hasAdminNoAccessToSection($adminUser, Section::zones())) {
             $configuration = $menu->getChildren()['configuration'] ?? null;
             if ($configuration) {
@@ -107,7 +104,6 @@ final class AdminMenuAccessListener
                 $configuration->removeChild('currencies');
             }
         }
-
         if ($this->hasAdminNoAccessToSection($adminUser, Section::locales())) {
             $configuration = $menu->getChildren()['configuration'] ?? null;
             if ($configuration) {
@@ -273,49 +269,48 @@ final class AdminMenuAccessListener
                 $menu->removeChild($customSection);
             }
         }
-
         $marketplace = $menu->getChildren()['marketplace'] ?? null;
         if ($marketplace) {
             if (count($marketplace->getChildren()) === 0) {
                 $menu->removeChild('marketplace');
             }
         }
-
         $catalog = $menu->getChildren()['catalog'] ?? null;
         if ($catalog) {
             if (count($catalog->getChildren()) === 0) {
                 $menu->removeChild('catalog');
             }
         }
-
         $sales = $menu->getChildren()['sales'] ?? null;
         if ($sales) {
             if (count($sales->getChildren()) === 0) {
                 $menu->removeChild('sales');
             }
         }
-        
+        $marketing = $menu->getChildren()['marketing'] ?? null;
+        if ($marketing) {
+            if (count($marketing->getChildren()) === 0) {
+                $menu->removeChild('marketing');
+            }
+        }
         $configuration = $menu->getChildren()['configuration'] ?? null;
         if ($configuration) {
             if (count($configuration->getChildren()) === 0) {
                 $menu->removeChild('configuration');
             }
         }
-
         $addressing = $menu->getChildren()['addressing'] ?? null;
         if ($addressing) {
             if (count($addressing->getChildren()) === 0) {
                 $menu->removeChild('addressing');
             }
         }
-
         $bitbag_cms = $menu->getChildren()['bitbag_cms'] ?? null;
         if ($bitbag_cms) {
             if (count($bitbag_cms->getChildren()) === 0) {
                 $menu->removeChild('bitbag_cms');
             }
         }
-        
     }
 
     private function hasAdminNoAccessToSection(AdminUserInterface $adminUser, Section $section): bool

--- a/src/Access/Menu/AdminMenuAccessListener.php
+++ b/src/Access/Menu/AdminMenuAccessListener.php
@@ -274,12 +274,48 @@ final class AdminMenuAccessListener
             }
         }
 
+        $marketplace = $menu->getChildren()['marketplace'] ?? null;
+        if ($marketplace) {
+            if (count($marketplace->getChildren()) === 0) {
+                $menu->removeChild('marketplace');
+            }
+        }
+
+        $catalog = $menu->getChildren()['catalog'] ?? null;
+        if ($catalog) {
+            if (count($catalog->getChildren()) === 0) {
+                $menu->removeChild('catalog');
+            }
+        }
+
+        $sales = $menu->getChildren()['sales'] ?? null;
+        if ($sales) {
+            if (count($sales->getChildren()) === 0) {
+                $menu->removeChild('sales');
+            }
+        }
+        
+        $configuration = $menu->getChildren()['configuration'] ?? null;
+        if ($configuration) {
+            if (count($configuration->getChildren()) === 0) {
+                $menu->removeChild('configuration');
+            }
+        }
+
         $addressing = $menu->getChildren()['addressing'] ?? null;
         if ($addressing) {
             if (count($addressing->getChildren()) === 0) {
                 $menu->removeChild('addressing');
             }
         }
+
+        $bitbag_cms = $menu->getChildren()['bitbag_cms'] ?? null;
+        if ($bitbag_cms) {
+            if (count($bitbag_cms->getChildren()) === 0) {
+                $menu->removeChild('bitbag_cms');
+            }
+        }
+        
     }
 
     private function hasAdminNoAccessToSection(AdminUserInterface $adminUser, Section $section): bool

--- a/src/Access/Menu/AdminMenuAccessListener.php
+++ b/src/Access/Menu/AdminMenuAccessListener.php
@@ -255,6 +255,12 @@ final class AdminMenuAccessListener
                 $config->removeChild('cities');
             }
         }
+        if ($this->hasAdminNoAccessToSection($adminUser, Section::provinces())) {
+            $config = $menu->getChildren()['addressing'] ?? null;
+            if ($config) {
+                $config->removeChild('provinces');
+            }
+        }
         if ($this->hasAdminNoAccessToSection($adminUser, Section::sections())) {
             $bitbag_cms = $menu->getChildren()['bitbag_cms'] ?? null;
             if ($bitbag_cms) {

--- a/src/Access/Menu/AdminMenuAccessListener.php
+++ b/src/Access/Menu/AdminMenuAccessListener.php
@@ -273,6 +273,13 @@ final class AdminMenuAccessListener
                 $menu->removeChild($customSection);
             }
         }
+
+        $addressing = $menu->getChildren()['addressing'] ?? null;
+        if ($addressing) {
+            if (count($addressing->getChildren()) === 0) {
+                $menu->removeChild('addressing');
+            }
+        }
     }
 
     private function hasAdminNoAccessToSection(AdminUserInterface $adminUser, Section $section): bool

--- a/src/Access/Menu/AdminMenuAccessListener.php
+++ b/src/Access/Menu/AdminMenuAccessListener.php
@@ -98,7 +98,7 @@ final class AdminMenuAccessListener
         if($this->hasAdminNoAccessToSection($adminUser, Section::administrators())){
             $configuration = $menu->getChildren()['configuration'] ?? null;
             if ($configuration) {
-                $configuration->removeChild('administrators');
+                $configuration->removeChild('admin_users');
             }
         }
         if ($this->hasAdminNoAccessToSection($adminUser, Section::currencies())) {

--- a/src/Access/Menu/AdminMenuAccessListener.php
+++ b/src/Access/Menu/AdminMenuAccessListener.php
@@ -146,6 +146,12 @@ final class AdminMenuAccessListener
                 $configuration->removeChild('tax_categories');
             }
         }
+        if ($this->hasAdminNoAccessToSection($adminUser, Section::packs())) {
+            $configuration = $menu->getChildren()['configuration'] ?? null;
+            if ($configuration) {
+                $configuration->removeChild('packs');
+            }
+        }
         if ($this->hasAdminNoAccessToSection($adminUser, Section::customers())) {
             $menu->removeChild('customers');
         }

--- a/src/Access/Model/Section.php
+++ b/src/Access/Model/Section.php
@@ -49,6 +49,8 @@ final class Section
     public const CITIES = 'cities_management';
     public const PROVINCES = 'provinces_management';
     public const PACKS = 'packs_management';
+    public const TESTIMONIALS = 'testimonials_management';
+    public const TESTIMONIALS_SECTIONS = 'testimonials_sections_management';
 
     private string $type;
 
@@ -238,6 +240,16 @@ final class Section
     public static function packs(): self
     {
         return new self(self::PACKS);
+    }
+
+    public static function testimonials(): self
+    {
+        return new self(self::TESTIMONIALS);
+    }
+
+    public static function testimonialsSections(): self
+    {
+        return new self(self::TESTIMONIALS_SECTIONS);
     }
 
     public static function ofType(string $type): self

--- a/src/Access/Model/Section.php
+++ b/src/Access/Model/Section.php
@@ -48,6 +48,7 @@ final class Section
     public const SECTIONS = 'sections_management';
     public const CITIES = 'cities_management';
     public const PROVINCES = 'provinces_management';
+    public const PACKS = 'packs_management';
 
     private string $type;
 
@@ -232,6 +233,11 @@ final class Section
     public static function provinces(): self
     {
         return new self(self::PROVINCES);
+    }
+
+    public static function packs(): self
+    {
+        return new self(self::PACKS);
     }
 
     public static function ofType(string $type): self

--- a/src/Access/Model/Section.php
+++ b/src/Access/Model/Section.php
@@ -47,6 +47,7 @@ final class Section
     public const FAQ = 'faq_management';
     public const SECTIONS = 'sections_management';
     public const CITIES = 'cities_management';
+    public const PROVINCES = 'provinces_management';
 
     private string $type;
 
@@ -226,6 +227,11 @@ final class Section
     public static function cities(): self
     {
         return new self(self::CITIES);
+    }
+
+    public static function provinces(): self
+    {
+        return new self(self::PROVINCES);
     }
 
     public static function ofType(string $type): self

--- a/src/Cli/InstallPluginCommand.php
+++ b/src/Cli/InstallPluginCommand.php
@@ -89,7 +89,8 @@ final class InstallPluginCommand extends Command
                 'currencies_management', 'administrators_management', 'exchange_rates_management',
                 'tax_categories_management', 'payment_methods_management',
                 'shipping_methods_management', 'association_types_management',
-                'shipping_categories_management', 'cities_management', 'provinces_management'
+                'shipping_categories_management', 'cities_management', 'provinces_management',
+                'packs_management', 'testimonials_management', 'testimonials_sections_management'
             ];
 
             foreach ($configuratorPermissions as $section) {

--- a/src/Cli/InstallPluginCommand.php
+++ b/src/Cli/InstallPluginCommand.php
@@ -89,7 +89,7 @@ final class InstallPluginCommand extends Command
                 'currencies_management', 'administrators_management', 'exchange_rates_management',
                 'tax_categories_management', 'payment_methods_management',
                 'shipping_methods_management', 'association_types_management',
-                'shipping_categories_management', 'cities_management'
+                'shipping_categories_management', 'cities_management', 'provinces_management'
             ];
 
             foreach ($configuratorPermissions as $section) {

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -65,6 +65,7 @@ final class Configuration implements ConfigurationInterface
                         ->arrayNode('sections_management')->prototype('scalar')->end()->end()
                         ->arrayNode('cities_management')->prototype('scalar')->end()->end()
                         ->arrayNode('provinces_management')->prototype('scalar')->end()->end()
+                        ->arrayNode('packs_management')->prototype('scalar')->end()->end()
                     ->end()
                 ->end()
                 ->arrayNode('custom_sections')
@@ -125,6 +126,7 @@ final class Configuration implements ConfigurationInterface
                 ->arrayNode('orders_management')->variablePrototype()->end()->end()
                 ->arrayNode('cities_management')->variablePrototype()->end()->end()
                 ->arrayNode('provinces_management')->variablePrototype()->end()->end()
+                ->arrayNode('packs_management')->variablePrototype()->end()->end()
             ->end()
         ;
     }

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -64,6 +64,7 @@ final class Configuration implements ConfigurationInterface
                         ->arrayNode('faq_management')->prototype('scalar')->end()->end()
                         ->arrayNode('sections_management')->prototype('scalar')->end()->end()
                         ->arrayNode('cities_management')->prototype('scalar')->end()->end()
+                        ->arrayNode('provinces_management')->prototype('scalar')->end()->end()
                     ->end()
                 ->end()
                 ->arrayNode('custom_sections')
@@ -123,6 +124,7 @@ final class Configuration implements ConfigurationInterface
                 ->arrayNode('payments_management')->variablePrototype()->end()->end()
                 ->arrayNode('orders_management')->variablePrototype()->end()->end()
                 ->arrayNode('cities_management')->variablePrototype()->end()->end()
+                ->arrayNode('provinces_management')->variablePrototype()->end()->end()
             ->end()
         ;
     }

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -66,6 +66,8 @@ final class Configuration implements ConfigurationInterface
                         ->arrayNode('cities_management')->prototype('scalar')->end()->end()
                         ->arrayNode('provinces_management')->prototype('scalar')->end()->end()
                         ->arrayNode('packs_management')->prototype('scalar')->end()->end()
+                        ->arrayNode('testimonials_management')->prototype('scalar')->end()->end()
+                        ->arrayNode('testimonials_sections_management')->prototype('scalar')->end()->end()
                     ->end()
                 ->end()
                 ->arrayNode('custom_sections')
@@ -127,6 +129,8 @@ final class Configuration implements ConfigurationInterface
                 ->arrayNode('cities_management')->variablePrototype()->end()->end()
                 ->arrayNode('provinces_management')->variablePrototype()->end()->end()
                 ->arrayNode('packs_management')->variablePrototype()->end()->end()
+                ->arrayNode('testimonials_management')->variablePrototype()->end()->end()
+                ->arrayNode('testimonials_sections_management')->variablePrototype()->end()->end()
             ->end()
         ;
     }

--- a/src/Model/Permission.php
+++ b/src/Model/Permission.php
@@ -55,6 +55,8 @@ final class Permission implements PermissionInterface
     public const FAQ_MANAGEMENT_PERMISSION = 'faq_management';
     public const SECTIONS_MANAGEMENT_PERMISSION = 'sections_management';
     public const CITIES_MANAGEMENT_PERMISSION = 'cities_management';
+    public const PROVINCES_MANAGEMENT_PERMISSION = 'provinces_management';
+
 
     private string $type;
 
@@ -198,6 +200,11 @@ final class Permission implements PermissionInterface
     public static function citiesManagement(array $operationTypes = []): self
     {
         return new self(self::CITIES_MANAGEMENT_PERMISSION, $operationTypes);
+    }
+
+    public static function provincesManagement(array $operationTypes = []): self
+    {
+        return new self(self::PROVINCES_MANAGEMENT_PERMISSION, $operationTypes);
     }
 
     public static function ofType(string $type, array $operationTypes = []): self

--- a/src/Model/Permission.php
+++ b/src/Model/Permission.php
@@ -56,7 +56,7 @@ final class Permission implements PermissionInterface
     public const SECTIONS_MANAGEMENT_PERMISSION = 'sections_management';
     public const CITIES_MANAGEMENT_PERMISSION = 'cities_management';
     public const PROVINCES_MANAGEMENT_PERMISSION = 'provinces_management';
-
+    public const PACKS_MANAGEMENT_PERMISSION = 'packs_management';
 
     private string $type;
 
@@ -205,6 +205,11 @@ final class Permission implements PermissionInterface
     public static function provincesManagement(array $operationTypes = []): self
     {
         return new self(self::PROVINCES_MANAGEMENT_PERMISSION, $operationTypes);
+    }
+
+    public static function packsManagement(array $operationTypes = []): self
+    {
+        return new self(self::PACKS_MANAGEMENT_PERMISSION, $operationTypes);
     }
 
     public static function ofType(string $type, array $operationTypes = []): self

--- a/src/Model/Permission.php
+++ b/src/Model/Permission.php
@@ -57,6 +57,9 @@ final class Permission implements PermissionInterface
     public const CITIES_MANAGEMENT_PERMISSION = 'cities_management';
     public const PROVINCES_MANAGEMENT_PERMISSION = 'provinces_management';
     public const PACKS_MANAGEMENT_PERMISSION = 'packs_management';
+    public const TESTIMONIALS_MANAGEMENT_PERMISSION = 'testimonials_management';
+    public const TESTIMONIALS_SECTIONS_MANAGEMENT_PERMISSION = 'testimonials_sections_management';
+
 
     private string $type;
 
@@ -210,6 +213,16 @@ final class Permission implements PermissionInterface
     public static function packsManagement(array $operationTypes = []): self
     {
         return new self(self::PACKS_MANAGEMENT_PERMISSION, $operationTypes);
+    }
+
+    public static function testimonialsManagement(array $operationTypes = []): self
+    {
+        return new self(self::TESTIMONIALS_MANAGEMENT_PERMISSION, $operationTypes);
+    }
+
+    public static function testimonialsSectionsManagement(array $operationTypes = []): self
+    {
+        return new self(self::TESTIMONIALS_SECTIONS_MANAGEMENT_PERMISSION, $operationTypes);
     }
 
     public static function ofType(string $type, array $operationTypes = []): self

--- a/src/Provider/SyliusSectionsProvider.php
+++ b/src/Provider/SyliusSectionsProvider.php
@@ -106,6 +106,18 @@ final class SyliusSectionsProvider implements SyliusSectionsProviderInterface
                 'app_pack_update',
                 'app_pack_delete',
             ],
+            'testimonials_management' => [
+                'app_admin_testimonial_index',
+                'app_admin_testimonial_create',
+                'app_admin_testimonial_update',
+                'app_admin_testimonial_delete',
+            ],
+            'testimonials_sections_management' => [
+                'app_admin_testimonials_section_index',
+                'app_admin_testimonials_section_create',
+                'app_admin_testimonials_section_update',
+                'app_admin_testimonials_section_delete',
+            ],
         ];
     }
 }

--- a/src/Provider/SyliusSectionsProvider.php
+++ b/src/Provider/SyliusSectionsProvider.php
@@ -96,6 +96,11 @@ final class SyliusSectionsProvider implements SyliusSectionsProviderInterface
                 'app_city_update',
                 'app_city_delete',
             ],
+            'provinces_management' => [
+                'app_province_index',
+                'app_province_update',
+                'app_province_delete',
+            ],
         ];
     }
 }

--- a/src/Provider/SyliusSectionsProvider.php
+++ b/src/Provider/SyliusSectionsProvider.php
@@ -101,6 +101,11 @@ final class SyliusSectionsProvider implements SyliusSectionsProviderInterface
                 'app_province_update',
                 'app_province_delete',
             ],
+            'packs_management' => [
+                'app_pack_index',
+                'app_pack_update',
+                'app_pack_delete',
+            ],
         ];
     }
 }

--- a/src/Resources/config/config.yaml
+++ b/src/Resources/config/config.yaml
@@ -101,6 +101,8 @@ odiseo_sylius_rbac:
       - bitbag_sylius_cms_plugin_admin_section_delete
     cities_management:
       - app_city
+    provinces_management:
+      - app_province
   custom_sections:
     rbac:
       - odiseo_sylius_rbac_plugin

--- a/src/Resources/config/config.yaml
+++ b/src/Resources/config/config.yaml
@@ -103,6 +103,8 @@ odiseo_sylius_rbac:
       - app_city
     provinces_management:
       - app_province
+    packs_management:
+      - app_pack
   custom_sections:
     rbac:
       - odiseo_sylius_rbac_plugin

--- a/src/Resources/config/config.yaml
+++ b/src/Resources/config/config.yaml
@@ -105,6 +105,10 @@ odiseo_sylius_rbac:
       - app_province
     packs_management:
       - app_pack
+    testimonials_management:
+      - app_admin_testimonial
+    testimonials_sections_management:
+      - app_admin_testimonials_section
   custom_sections:
     rbac:
       - odiseo_sylius_rbac_plugin

--- a/src/Resources/translations/messages.en.yml
+++ b/src/Resources/translations/messages.en.yml
@@ -48,6 +48,7 @@ odiseo_sylius_rbac_plugin:
       content_management: "Content management"
       faq_management: "FAQ management"
       cities_management: "Cities management"
+      provinces_management: "Provinces management"
       media_management: "Media management"
       sections_management: "Sections management"
       operation_type:

--- a/src/Resources/translations/messages.en.yml
+++ b/src/Resources/translations/messages.en.yml
@@ -50,6 +50,8 @@ odiseo_sylius_rbac_plugin:
       cities_management: "Cities management"
       provinces_management: "Provinces management"
       packs_management: "Packs management"
+      testimonials_management: "Testimonials management"
+      testimonials_sections_management: "Testimonials sections management"
       media_management: "Media management"
       sections_management: "Sections management"
       operation_type:

--- a/src/Resources/translations/messages.en.yml
+++ b/src/Resources/translations/messages.en.yml
@@ -49,6 +49,7 @@ odiseo_sylius_rbac_plugin:
       faq_management: "FAQ management"
       cities_management: "Cities management"
       provinces_management: "Provinces management"
+      packs_management: "Packs management"
       media_management: "Media management"
       sections_management: "Sections management"
       operation_type:

--- a/src/Resources/translations/messages.fr.yml
+++ b/src/Resources/translations/messages.fr.yml
@@ -49,6 +49,7 @@ odiseo_sylius_rbac_plugin:
       faq_management: "Gestion des FAQ"
       cities_management: "Gestion des villes"
       provinces_management: "Gestion des provinces"
+      packs_management: "Gestion des packs"
       media_management: "Gestion des médias"
       sections_management: "Gestion des sections"
       operation_type:

--- a/src/Resources/translations/messages.fr.yml
+++ b/src/Resources/translations/messages.fr.yml
@@ -50,6 +50,8 @@ odiseo_sylius_rbac_plugin:
       cities_management: "Gestion des villes"
       provinces_management: "Gestion des provinces"
       packs_management: "Gestion des packs"
+      testimonials_management: "Gestion des témoignages"
+      testimonials_sections_management: "Gestion des sections de témoignages"
       media_management: "Gestion des médias"
       sections_management: "Gestion des sections"
       operation_type:

--- a/src/Resources/translations/messages.fr.yml
+++ b/src/Resources/translations/messages.fr.yml
@@ -48,6 +48,7 @@ odiseo_sylius_rbac_plugin:
       content_management: "Gestion du contenu"
       faq_management: "Gestion des FAQ"
       cities_management: "Gestion des villes"
+      provinces_management: "Gestion des provinces"
       media_management: "Gestion des médias"
       sections_management: "Gestion des sections"
       operation_type:


### PR DESCRIPTION
This PR adds Role-Based Access Control (RBAC) support for four new management sections:
- **Provinces Management** (under addressing section)
- **Packs Management** (under configuration section)
- **Testimonials Management** (under bitbag_cms section)
- **Testimonials Sections Management** (under bitbag_cms section)
## Changes include:
- Added new Section constants and methods
- Updated configuration files with route mappings
- Added menu access control logic
- Added translations in English and French
- Extended AccessRequestCreator with new route checking

The implementation follows the existing pattern for cities management and integrates seamlessly with the current RBAC system.
